### PR TITLE
feat: Inject full route catalog and update search logic

### DIFF
--- a/rust-wasm/shared-types/src/lib.rs
+++ b/rust-wasm/shared-types/src/lib.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum TransportType {
+    // Legacy Variants (Keep for compatibility)
     #[serde(rename = "Bus_HotelZone")]
     BusHotelZone,
     #[serde(rename = "Bus_Urban")]
@@ -12,6 +13,16 @@ pub enum TransportType {
     PlayaExpress,
     #[serde(rename = "ADO_Airport")]
     AdoAirport,
+
+    // New Generic Variants (For Truth of the Street)
+    #[serde(rename = "Bus")]
+    Bus,
+    #[serde(rename = "Combi")]
+    Combi,
+    #[serde(rename = "Van")]
+    Van,
+    #[serde(rename = "ADO")]
+    ADO,
 }
 
 impl Default for TransportType {


### PR DESCRIPTION
This PR injects the full "Truth of the Street" route catalog into the Rust WASM module. It updates the `Route` struct to support detailed stop lists and implements a new fuzzy search logic that checks all stops in a route, not just the hubs. The `TransportType` enum was updated additively to support new generic types while preserving legacy variants.

---
*PR created automatically by Jules for task [16091770701236384788](https://jules.google.com/task/16091770701236384788) started by @sistemascancunjefe-ai*