### PR TITLE
Fix missing getTransportLabel import in RouteCalculator client script

### DIFF
--- a/src/components/RouteCalculator.astro
+++ b/src/components/RouteCalculator.astro
@@ -169,6 +169,7 @@ const ui = uiTranslations[currentLang];
   import { CoordinateFinder } from '../utils/CoordinateFinder';
   import { escapeHtml, safeJsonStringify } from '../utils/utils';
   import { getWalletBalance, setWalletBalance } from '../utils/db';
+  import { getTransportLabel } from '../utils/transport';
 
   let currentLang = document.documentElement.lang || 'es';
   const i18nDataEl = document.getElementById('i18n-data');


### PR DESCRIPTION
This commit adds the missing `getTransportLabel` import to the client-side
script tag in `RouteCalculator.astro`. Without this import, calculating a
route would fail with a ReferenceError when trying to render the results,
preventing any routes from being displayed.

---
*PR created automatically by Jules for task [4010265261763433907](https://jules.google.com/task/4010265261763433907) started by @sistemascancunjefe-ai*