### PR TITLE
fix: add missing WasmLoader import to RouteCalculator.astro

### DIFF
--- a/src/components/RouteCalculator.astro
+++ b/src/components/RouteCalculator.astro
@@ -175,6 +175,7 @@ const ui = uiTranslations[currentLang];
   import { escapeHtml, safeJsonStringify } from '../utils/utils';
   import { getWalletBalance, setWalletBalance } from '../utils/db';
   import { getTransportLabel } from '../utils/transport';
+  import { WasmLoader } from '../utils/WasmLoader';
 
   let currentLang = document.documentElement.lang || 'es';
   const i18nDataEl = document.getElementById('i18n-data');


### PR DESCRIPTION
Resolves critical error where WasmLoader was not defined in the client-side script of RouteCalculator.astro by importing it from the utils directory.

---
*PR created automatically by Jules for task [4539506345786566187](https://jules.google.com/task/4539506345786566187) started by @sistemascancunjefe-ai*