### PR TITLE
test: add unit tests for getCurrentPosition utility

### DIFF
--- a/src/tests/geolocation.test.ts
+++ b/src/tests/geolocation.test.ts
@@ -1,0 +1,82 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getCurrentPosition } from '../utils/geolocation';
+
+describe('getCurrentPosition', () => {
+  const mockGeolocation = {
+    getCurrentPosition: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('navigator', {
+      geolocation: mockGeolocation,
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should resolve with position when successful', async () => {
+    const mockPosition = {
+      coords: {
+        latitude: 21.1619,
+        longitude: -86.8249,
+        accuracy: 10,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+      },
+      timestamp: Date.now(),
+    };
+
+    mockGeolocation.getCurrentPosition.mockImplementationOnce((success) => {
+      success(mockPosition);
+    });
+
+    const position = await getCurrentPosition();
+    expect(position).toEqual(mockPosition);
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        enableHighAccuracy: true,
+        timeout: 5000,
+        maximumAge: 0,
+      })
+    );
+  });
+
+  it('should reject when geolocation fails', async () => {
+    const mockError = {
+      code: 1,
+      message: 'User denied Geolocation',
+    };
+
+    mockGeolocation.getCurrentPosition.mockImplementationOnce((success, error) => {
+      error(mockError);
+    });
+
+    await expect(getCurrentPosition()).rejects.toEqual(mockError);
+  });
+
+  it('should use correct geolocation options', async () => {
+    mockGeolocation.getCurrentPosition.mockImplementationOnce((success) => {
+      success({});
+    });
+
+    await getCurrentPosition();
+
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      {
+        enableHighAccuracy: true,
+        timeout: 5000,
+        maximumAge: 0,
+      }
+    );
+  });
+});


### PR DESCRIPTION
- Created src/tests/geolocation.test.ts
- Mocked navigator.geolocation using vi.stubGlobal
- Added tests for success, error, and configuration options
- Ensured JSDOM environment for browser API testing
- Added afterEach cleanup with vi.unstubAllGlobals()