### PR TITLE
🔒 [security fix] Move GitHub token to secure API route

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config"
 import mdx from "@astrojs/mdx"
 import tailwind from "@astrojs/tailwind"
+import node from "@astrojs/node"
 import path from "path"
 import { fileURLToPath } from "url"
 
@@ -9,7 +10,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // https://astro.build/config
 export default defineConfig({
   site: "https://querutamellevacancun.onrender.com",
-  output: 'static',
+  output: 'hybrid',
+  adapter: node({
+    mode: "standalone"
+  }),
   integrations: [
     mdx(),
     tailwind({ applyBaseStyles: false })

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^4.0.0",
+    "@astrojs/node": "^9.1.1",
     "@astrojs/rss": "^4.0.5",
     "@astrojs/tailwind": "^5.1.0",
     "@rollup/rollup-linux-x64-gnu": "^4.57.1",

--- a/render.yaml
+++ b/render.yaml
@@ -7,7 +7,7 @@ projects:
     services:
     - type: web
       name: QueRutaMeLLevaCancun
-      runtime: static
+      runtime: node
       repo: https://github.com/JULIANJUAREZMX01/MueveCancun
       envVars:
       - key: NODE_VERSION
@@ -15,7 +15,7 @@ projects:
       - key: ENABLE_PNPM
         sync: false
       buildCommand: bash scripts/setup-render.sh
-      staticPublishPath: dist
+      startCommand: node dist/server/entry.mjs
       autoDeployTrigger: checksPass
       previews:
         generation: automatic

--- a/src/components/ReportWidget.astro
+++ b/src/components/ReportWidget.astro
@@ -10,9 +10,7 @@ interface Props {
   repoName?: string;
 }
 
-const repoOwner = Astro.props.repoOwner ?? import.meta.env.GITHUB_REPO_OWNER ?? "JULIANJUAREZMX01";
-const repoName = Astro.props.repoName ?? import.meta.env.GITHUB_REPO_NAME ?? "MueveCancun";
-const githubToken = import.meta.env.GITHUB_ISSUES_TOKEN ?? "";
+const { repoOwner, repoName } = Astro.props;
 ---
 
 <!-- Botón flotante — visible en todas las páginas vía Layout -->
@@ -338,7 +336,7 @@ const githubToken = import.meta.env.GITHUB_ISSUES_TOKEN ?? "";
   }
 </style>
 
-<script define:vars={{ repoOwner, repoName, githubToken }}>
+<script is:inline define:vars={{ repoOwner, repoName }}>
   /** @type {any} */
   (() => {
     // ── Referencias DOM ──────────────────────────────────────────
@@ -492,7 +490,7 @@ _Versión: Nexus Protocol 1.1_
 `;
     };
 
-    // ── Envío → GitHub Issues API ─────────────────────────────────
+    // ── Envío → Backend API ───────────────────────────────────────
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
 
@@ -504,7 +502,7 @@ _Versión: Nexus Protocol 1.1_
       const lng = formData.get('lng') || '';
 
       if (!tipo) { showFeedback('Selecciona el tipo de problema.', 'error'); return; }
-      if (!descripcion || descripcion.toString().trim().length < 10) {
+      if (!descripcion || (descripcion).toString().trim().length < 10) {
         showFeedback('La descripción es muy corta, agrega más detalle.', 'error');
         return;
       }
@@ -512,42 +510,32 @@ _Versión: Nexus Protocol 1.1_
       setSubmitting(true);
       if (feedback) feedback.hidden = true;
 
-      const issuePayload = {
-        title:  `[REPORTE] ${TIPO_TITLES[tipo] ?? tipo}${ruta ? ` — ${ruta}` : ''}`,
-        body:   buildIssueBody({
-          tipo,
-          ruta,
-          descripcion,
-          lat,
-          lng,
-          userAgent: navigator.userAgent,
-          url: window.location.href
-        }),
-        labels: TIPO_LABELS[tipo] ?? ['reporte', 'estado:pendiente'],
+      const payload = {
+        tipo,
+        ruta,
+        descripcion,
+        lat,
+        lng,
+        repoOwner,
+        repoName,
+        userAgent: navigator.userAgent,
+        url: window.location.href
       };
 
       try {
-        const res = await fetch(
-          `https://api.github.com/repos/${repoOwner}/${repoName}/issues`,
-          {
-            method: 'POST',
-            headers: {
-              'Accept':        'application/vnd.github+json',
-              'Authorization': `Bearer ${githubToken}`,
-              'X-GitHub-Api-Version': '2022-11-28',
-              'Content-Type':  'application/json',
-            },
-            body: JSON.stringify(issuePayload),
-          }
-        );
+        const res = await fetch('/api/report', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
 
         if (res.ok) {
-          const issue = await res.json();
-          showFeedback(`¡Gracias! Reporte enviado (#${issue.number})`, 'success');
+          const data = await res.json();
+          showFeedback(`¡Gracias! Reporte enviado (#${data.number})`, 'success');
           setTimeout(closeModal, 2800);
         } else {
           const errData = await res.json().catch(() => ({}));
-          console.error('[ReportWidget] GitHub API error:', res.status, errData);
+          console.error('[ReportWidget] API error:', res.status, errData);
           showFeedback(
             res.status === 401
               ? 'Error de autenticación. Contacta al admin.'

--- a/src/pages/api/report.ts
+++ b/src/pages/api/report.ts
@@ -1,0 +1,96 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+const TIPO_TITLES: Record<string, string> = {
+  precio:     'Precio incorrecto',
+  ruta:       'Ruta / destino mal',
+  nueva:      'Ruta nueva no listada',
+  cancelada:  'Ruta cancelada o fuera de servicio',
+  comentario: 'Información importante',
+};
+
+const TIPO_LABELS: Record<string, string[]> = {
+  precio:     ['reporte:precio',    'estado:pendiente'],
+  ruta:       ['reporte:ruta',      'estado:pendiente'],
+  nueva:      ['reporte:nueva-ruta','estado:pendiente'],
+  cancelada:  ['reporte:cancelada', 'estado:pendiente'],
+  comentario: ['reporte:info',      'estado:pendiente'],
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const data = await request.json();
+    const { tipo, ruta, descripcion, lat, lng, repoOwner: propRepoOwner, repoName: propRepoName, userAgent, url } = data;
+
+    if (!tipo || !TIPO_TITLES[tipo]) {
+      return new Response(JSON.stringify({ error: 'Tipo de reporte inválido.' }), { status: 400 });
+    }
+
+    if (!descripcion || descripcion.trim().length < 10) {
+      return new Response(JSON.stringify({ error: 'La descripción es muy corta.' }), { status: 400 });
+    }
+
+    const repoOwner = propRepoOwner ?? import.meta.env.GITHUB_REPO_OWNER ?? "JULIANJUAREZMX01";
+    const repoName = propRepoName ?? import.meta.env.GITHUB_REPO_NAME ?? "MueveCancun";
+    const githubToken = import.meta.env.GITHUB_ISSUES_TOKEN;
+
+    if (!githubToken) {
+      console.error('[API/report] GITHUB_ISSUES_TOKEN is not configured.');
+      return new Response(JSON.stringify({ error: 'Error de configuración en el servidor.' }), { status: 500 });
+    }
+
+    const geoSection = lat && lng
+      ? `\n## 📍 Ubicación del reporte\n\`${lat}, ${lng}\`\n[Ver en mapa](https://www.openstreetmap.org/?mlat=${lat}&mlon=${lng}#map=16/${lat}/${lng})\n`
+      : '';
+
+    const body = `## 📋 Reporte ciudadano — MueveCancun
+
+**Tipo:** ${TIPO_TITLES[tipo] ?? tipo}
+**Ruta afectada:** ${ruta || '_No especificada_'}
+**Fecha:** ${new Date().toLocaleString('es-MX', { timeZone: 'America/Cancun' })} (Hora Cancún)
+
+## 📝 Descripción
+
+${descripcion}
+${geoSection}
+---
+_Reportado desde: ${url}_
+_Dispositivo: ${userAgent}_
+_Versión: Nexus Protocol 1.1_
+`;
+
+    const issuePayload = {
+      title:  `[REPORTE] ${TIPO_TITLES[tipo] ?? tipo}${ruta ? ` — ${ruta}` : ''}`,
+      body,
+      labels: TIPO_LABELS[tipo] ?? ['reporte', 'estado:pendiente'],
+    };
+
+    const res = await fetch(
+      `https://api.github.com/repos/${repoOwner}/${repoName}/issues`,
+      {
+        method: 'POST',
+        headers: {
+          'Accept':        'application/vnd.github+json',
+          'Authorization': `Bearer ${githubToken}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+          'Content-Type':  'application/json',
+          'User-Agent':    'MueveCancun-Report-Widget'
+        },
+        body: JSON.stringify(issuePayload),
+      }
+    );
+
+    if (res.ok) {
+      const issue = await res.json();
+      return new Response(JSON.stringify({ number: issue.number }), { status: 200 });
+    } else {
+      const errData = await res.json().catch(() => ({}));
+      console.error('[API/report] GitHub API error:', res.status, errData);
+      return new Response(JSON.stringify({ error: `Error de GitHub: ${res.status}` }), { status: res.status });
+    }
+  } catch (err) {
+    console.error('[API/report] Unexpected error:', err);
+    return new Response(JSON.stringify({ error: 'Internal Server Error' }), { status: 500 });
+  }
+};


### PR DESCRIPTION
I have fixed the security vulnerability in the `ReportWidget.astro` component where the GitHub Issues token was exposed to the client.

### 🎯 What:
The vulnerability was an exposed `GITHUB_ISSUES_TOKEN` in the frontend code, which could be easily extracted by anyone visiting the site.

### ⚠️ Risk:
An exposed GitHub token allows unauthorized access to the repository's issues API, potentially leading to spam, information disclosure, or other malicious activities.

### 🛡️ Solution:
I moved the GitHub API interaction to a new secure server-side API route.
1.  **Astro Hybrid Mode**: Configured Astro to use `output: 'hybrid'` and the `@astrojs/node` adapter to support server-side endpoints while keeping the rest of the site static.
2.  **Secure API Endpoint**: Created `src/pages/api/report.ts` which uses the `GITHUB_ISSUES_TOKEN` from server-side environment variables to create issues via the GitHub API.
3.  **Component Refactor**: Updated `ReportWidget.astro` to remove the sensitive token from the client-side script and instead send report data to our new internal API.
4.  **Deployment Update**: Updated `render.yaml` to use the Node.js runtime required for the hybrid architecture.
5.  **Robustness**: Ensured that the `repoOwner` and `repoName` props still function correctly and fixed a script syntax error identified during code review.

---
*PR created automatically by Jules for task [14825591171839425240](https://jules.google.com/task/14825591171839425240) started by @sistemascancunjefe-ai*