### PR TITLE
Add testing support for Set and Map objects in debugString

### DIFF
--- a/public/wasm/spatial-index/spatial_index.js
+++ b/public/wasm/spatial-index/spatial_index.js
@@ -254,7 +254,12 @@ function debugString(val) {
     if (val instanceof Error) {
         return `${val.name}: ${val.message}\n${val.stack}`;
     }
-    // TODO we could test for more things here, like `Set`s and `Map`s.
+    if (val instanceof Set) {
+        return `Set(${debugString(Array.from(val))})`;
+    }
+    if (val instanceof Map) {
+        return `Map(${debugString(Array.from(val))})`;
+    }
     return className;
 }
 

--- a/src/wasm/route_calculator.js
+++ b/src/wasm/route_calculator.js
@@ -320,7 +320,12 @@ function debugString(val) {
     if (val instanceof Error) {
         return `${val.name}: ${val.message}\n${val.stack}`;
     }
-    // TODO we could test for more things here, like `Set`s and `Map`s.
+    if (val instanceof Set) {
+        return `Set(${debugString(Array.from(val))})`;
+    }
+    if (val instanceof Map) {
+        return `Map(${debugString(Array.from(val))})`;
+    }
     return className;
 }
 


### PR DESCRIPTION
This PR implements support for serializing JavaScript `Set` and `Map` objects in the `debugString` utility function used by WASM-bindgen generated code.

Previously, `debugString` only handled primitives, Arrays, and basic Objects, leaving `Set` and `Map` as a TODO. The new implementation uses `Array.from()` to convert these collections into arrays, which are then recursively serialized, resulting in readable strings like `Set([1, 2])` or `Map([[1, "a"]])`.

Modified Files:
- `src/wasm/route_calculator.js`: Core WASM glue code source.
- `public/wasm/spatial-index/spatial_index.js`: Spatial index WASM glue code artifact.

Verification:
- Created a `test_debug_string.js` script that imports `debugString` from the source and asserts correct output for all supported types.
- Verified that existing WASM artifacts were preserved and not negatively impacted by the changes.

---
*PR created automatically by Jules for task [3934553907883901556](https://jules.google.com/task/3934553907883901556) started by @sistemascancunjefe-ai*