### PR TITLE
Potential fix for code scanning alert no. 50: Information exposure through a stack trace

### DIFF
--- a/src/pages/api/v1/trips.ts
+++ b/src/pages/api/v1/trips.ts
@@ -77,8 +77,8 @@ export const POST: APIRoute = async ({ request }) => {
 
     return new Response(JSON.stringify({ error: 'action must be: start|end' }), { status: 400 });
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return new Response(JSON.stringify({ error: msg }), { status: 500 });
+    console.error('POST /api/v1/trips failed:', e);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500 });
   }
 };
 
@@ -90,6 +90,7 @@ export const GET: APIRoute = async ({ url }) => {
     const trips = await sql`SELECT * FROM mc_trips WHERE device_id=${device_id} ORDER BY started_at DESC LIMIT 20`;
     return new Response(JSON.stringify(trips), { status: 200, headers: { 'Content-Type': 'application/json' } });
   } catch (e) {
-    return new Response(JSON.stringify({ error: String(e) }), { status: 500 });
+    console.error('GET /api/v1/trips failed:', e);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500 });
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/JULIANJUAREZMX01/MueveCancun/security/code-scanning/50](https://github.com/JULIANJUAREZMX01/MueveCancun/security/code-scanning/50)

To fix this without changing functional behavior, keep HTTP 500 responses but stop sending exception content to clients. Instead:

- In `POST` catch block (lines 79–82), log the caught error internally (server console) and return a generic message like `"Internal server error"`.
- In `GET` catch block (lines 92–94), do the same.
- No new dependency is required; `console.error` is sufficient and standard.

This preserves current control flow/status codes while removing sensitive error disclosure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
