### PR TITLE
ci: enforce single Astro config and validate generated routes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,17 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - run: pnpm install --frozen-lockfile
+  astro-config:
+    name: Astro Config Integrity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: pnpm/action-setup@0c17529a66aca453f9227af23103ed11469b1e47
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - run: pnpm check:astro-config
   lint:
     name: Lint & Prettier
     needs: environment
@@ -81,7 +92,7 @@ jobs:
       - run: node --experimental-strip-types scripts/validate-routes.ts
   build-vercel:
     name: Production Build (Vercel)
-    needs: [lint, ts-unit, rust-unit, data-integrity]
+    needs: [astro-config, lint, ts-unit, rust-unit, data-integrity]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -98,3 +109,5 @@ jobs:
         env:
           NODE_ENV: production
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      - name: Validate generated server routes
+        run: pnpm test:dist-routes

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "start": "node dist/server/entry.mjs",
     "build:ci": "pnpm prepare-data && node scripts/build-wasm.mjs && pnpm exec tsc -p tsconfig.client.json && pnpm exec tsc -p tsconfig.sw.json && pnpm exec astro build",
     "db:migrate": "node --experimental-strip-types scripts/db-migrate.ts",
-    "build:vercel": "pnpm prepare-data && node scripts/build-wasm.mjs && pnpm exec astro build"
+    "build:vercel": "pnpm prepare-data && node scripts/build-wasm.mjs && pnpm exec astro build",
+    "check:astro-config": "node scripts/check-astro-config.mjs",
+    "test:dist-routes": "node scripts/validate-dist-routes.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "^6.0.1",

--- a/scripts/check-astro-config.mjs
+++ b/scripts/check-astro-config.mjs
@@ -1,0 +1,18 @@
+import { readdir } from 'node:fs/promises';
+import process from 'node:process';
+
+const EXPECTED_CONFIG = 'astro.config.ts';
+const entries = await readdir(process.cwd(), { withFileTypes: true });
+const configs = entries
+  .filter((entry) => entry.isFile() && entry.name.startsWith('astro.config.'))
+  .map((entry) => entry.name)
+  .sort();
+
+if (configs.length !== 1 || configs[0] !== EXPECTED_CONFIG) {
+  console.error(
+    `[astro-config] Expected ${EXPECTED_CONFIG} to be the only Astro config, found: ${configs.join(', ') || 'none'}`,
+  );
+  process.exit(1);
+}
+
+console.log(`[astro-config] OK — using only ${EXPECTED_CONFIG}`);

--- a/scripts/validate-dist-routes.mjs
+++ b/scripts/validate-dist-routes.mjs
@@ -1,0 +1,70 @@
+import { spawn } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import process from 'node:process';
+
+const HOST = '127.0.0.1';
+const PORT = process.env.DIST_SERVER_PORT ?? '4322';
+const BASE_URL = `http://${HOST}:${PORT}`;
+const ENTRYPOINT = 'dist/server/entry.mjs';
+const ROUTES = [
+  '/es/home',
+  '/es/tracking',
+  '/es/rutas',
+  '/es/guess',
+  '/es/contribuir',
+  '/es/suscripcion',
+];
+
+const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function waitForServer(child, timeoutMs = 30_000) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (child.exitCode !== null) {
+      throw new Error(`Generated server exited early with code ${child.exitCode}`);
+    }
+
+    try {
+      const response = await fetch(`${BASE_URL}/healthz`);
+      if (response.ok) return;
+    } catch {
+      // The generated server is still starting.
+    }
+
+    await wait(250);
+  }
+
+  throw new Error(`Generated server did not start within ${timeoutMs}ms`);
+}
+
+async function validateRoutes() {
+  await access(ENTRYPOINT);
+
+  const server = spawn(process.execPath, [ENTRYPOINT], {
+    env: { ...process.env, HOST, PORT },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  server.stdout.on('data', (chunk) => process.stdout.write(`[dist-server] ${chunk}`));
+  server.stderr.on('data', (chunk) => process.stderr.write(`[dist-server:error] ${chunk}`));
+
+  try {
+    await waitForServer(server);
+
+    for (const route of ROUTES) {
+      const response = await fetch(`${BASE_URL}${route}`, { redirect: 'manual' });
+      if (response.status !== 200) {
+        throw new Error(`${route} returned HTTP ${response.status}`);
+      }
+      console.log(`[dist-routes] OK — ${route} returned HTTP 200`);
+    }
+  } finally {
+    server.kill('SIGTERM');
+  }
+}
+
+validateRoutes().catch((error) => {
+  console.error('[dist-routes] FAIL:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Ensure the project uses a single canonical Astro configuration (`astro.config.ts`) to avoid Astro selecting an unexpected config during CI or builds.
- Guarantee the production build produces an SSR server (`output: "server"`) with the expected adapter and that critical localized routes are served from the generated `dist/` server.
- Fail fast in CI when duplicate `astro.config.*` files exist to prevent silent regressions in deployments.

### Description

- Added `scripts/check-astro-config.mjs` which fails unless `astro.config.ts` is the only `astro.config.*` file in the repository. 
- Added `scripts/validate-dist-routes.mjs` which starts `dist/server/entry.mjs` and verifies HTTP 200 for `/es/home`, `/es/tracking`, `/es/rutas`, `/es/guess`, `/es/contribuir` and `/es/suscripcion`.
- Exposed the checks via `package.json` scripts `check:astro-config` and `test:dist-routes` and updated CI (`.github/workflows/test.yml`) to run an `Astro Config Integrity` job and require it before the production build, and to validate generated routes after the build.
- Confirmed `astro.config.ts` remains the single config with `output: 'server'` and selects `@astrojs/node` adapter in non-Vercel environments.

### Testing

- Ran `pnpm check:astro-config` which succeeded when only `astro.config.ts` existed and failed the negative test after creating a temporary `astro.config.mjs`. 
- Executed a production build with `NODE_ENV=production pnpm build:vercel` and verified Astro logged `output: "server"`, `mode: "server"` and `adapter: @astrojs/node`. 
- Ran `pnpm test:dist-routes` against the generated `dist/` server and all six localized routes returned HTTP 200. 
- Ran `pnpm lint`, `pnpm test -- --run` (Vitest) which completed with all tests passing (19 test files, 156 tests passed, 1 todo), and `pnpm audit:survival`, all of which passed; a transient `wasm-pack` postinstall network error was observed during one `pnpm install` run but did not affect CI checks after installing with `--ignore-scripts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2502d019c48325aa04b12228eecf49)