### PR TITLE
feat(tracking): expose mode (live|mixed|demo|offline), disableable stubs, and demo UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ DATABASE_URL=postgresql://user:pass@ep-xxx.neon.tech/neondb?sslmode=require
 # Proveedor activo: 'neon' (default) | 'supabase'
 DATABASE_PROVIDER=neon
 
+# Tracking: false desactiva por completo unidades simuladas/stubs (recomendado en producción)
+TRACKING_STUBS_ENABLED=false
+
 # ─── Neon (para GitHub Actions — branch preview por PR) ──────────
 # Obtener en: https://console.neon.tech → Settings → API Keys
 NEON_API_KEY=your_neon_api_key

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -46,6 +46,7 @@ PR cerrado → Neon branch eliminada automáticamente
 |---|---|---|
 | `DATABASE_URL` | `postgresql://...neon.tech/neondb?sslmode=require` | Production + Preview |
 | `DATABASE_PROVIDER` | `neon` | Production + Preview |
+| `TRACKING_STUBS_ENABLED` | `false` | Production (desactiva unidades demo) |
 | `STRIPE_SECRET_KEY` | `sk_live_...` | Production |
 | `STRIPE_SECRET_KEY` | `sk_test_...` | Preview + Development |
 | `STRIPE_WEBHOOK_SECRET` | `whsec_...` | Production |

--- a/src/components/InteractiveMap.astro
+++ b/src/components/InteractiveMap.astro
@@ -85,7 +85,8 @@ const isEs = Astro.url.pathname.includes("/es/");
       ]);
       if (!trackRes.ok || !routesRes.ok) return;
 
-      const units = await trackRes.json();
+      const trackingPayload = await trackRes.json();
+      const units = Array.isArray(trackingPayload) ? trackingPayload : trackingPayload?.units || [];
       const routesData = await routesRes.json();
       const routes = routesData.rutas || routesData;
       const colorMap = {};

--- a/src/pages/[lang]/tracking.astro
+++ b/src/pages/[lang]/tracking.astro
@@ -9,7 +9,6 @@ const t = {
   busesTitle: lang === 'es' ? 'Buses en ruta' : 'Buses on route',
   heatmap:  lang === 'es' ? 'Mapa de calor' : 'Heat map',
   stops:    lang === 'es' ? 'Paraderos' : 'Stops',
-  live:     lang === 'es' ? 'En vivo' : 'Live',
   waiting:  lang === 'es' ? 'esperando' : 'waiting',
   low: lang === 'es' ? 'Bajo' : 'Low',
   medium: lang === 'es' ? 'Medio' : 'Medium',
@@ -23,9 +22,9 @@ const t = {
     <!-- Header bar -->
     <div class="tracking-header glass-card">
       <div class="tracking-header__left">
-        <div class="live-badge">
+        <div id="tracking-mode-badge" class="live-badge mode-offline" aria-live="polite">
           <span class="live-dot"></span>
-          <span>{t.live}</span>
+          <span id="tracking-mode-label">Offline</span>
         </div>
         <h1 class="tracking-title">{t.title}</h1>
       </div>
@@ -43,6 +42,10 @@ const t = {
 
     <!-- Map container -->
     <div id="tracking-map" class="tracking-map"></div>
+    <div id="tracking-legend" class="tracking-legend" hidden>
+      <span class="legend-demo-marker">DEMO</span>
+      <span>{lang === 'es' ? 'Unidades simuladas, no posiciones reales' : 'Simulated units, not real positions'}</span>
+    </div>
 
     <!-- Bottom panel — buses list -->
     <div id="buses-panel" class="buses-panel glass-card">
@@ -76,8 +79,13 @@ const t = {
 .tracking-header__left { display: flex; align-items: center; gap: 0.75rem; }
 .tracking-header__right { display: flex; align-items: center; gap: 0.5rem; }
 .tracking-title { font-family: var(--font-display); font-size: 1rem; font-weight: 700; color: var(--text-primary); margin: 0; }
-.live-badge { display: flex; align-items: center; gap: 0.3rem; background: var(--danger-light); color: var(--danger); font-size: 0.65rem; font-weight: 700; padding: 0.2rem 0.5rem; border-radius: 99px; letter-spacing: 0.05em; text-transform: uppercase; }
-.live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--danger); animation: pulse-red 1.2s ease-in-out infinite; }
+.live-badge { display: flex; align-items: center; gap: 0.3rem; font-size: 0.65rem; font-weight: 700; padding: 0.2rem 0.5rem; border-radius: 99px; letter-spacing: 0.05em; text-transform: uppercase; }
+.live-badge.mode-live { background: #dcfce7; color: #15803d; }
+.live-badge.mode-mixed { background: #fef3c7; color: #a16207; }
+.live-badge.mode-demo { background: #ffedd5; color: #c2410c; }
+.live-badge.mode-offline { background: var(--surface-inset); color: var(--text-tertiary); }
+.live-dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; animation: pulse-red 1.2s ease-in-out infinite; }
+.mode-offline .live-dot { animation: none; }
 @keyframes pulse-red { 0%,100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.5; transform: scale(1.4); } }
 .route-select { background: var(--surface-card); border: 1.5px solid var(--border-medium); border-radius: 10px; padding: 0.4rem 0.6rem; font-size: 0.8rem; color: var(--text-primary); min-width: 120px; }
 .view-toggle { display: flex; gap: 0.25rem; background: var(--surface-inset); border-radius: 10px; padding: 0.2rem; }
@@ -89,6 +97,18 @@ const t = {
   flex: 1; width: 100%; min-height: 0;
   position: relative; z-index: 1;
 }
+.tracking-legend {
+  position: absolute; z-index: 9; top: 4.5rem; left: 0.75rem; right: 4rem;
+  display: flex; align-items: center; gap: 0.45rem; width: fit-content; max-width: calc(100% - 5rem);
+  padding: 0.45rem 0.65rem; border: 2px dashed #f59e0b; border-radius: 10px;
+  background: rgba(255, 247, 237, 0.96); color: #9a3412; box-shadow: 0 2px 8px rgba(154, 52, 18, 0.18);
+  font-size: 0.7rem; font-weight: 700;
+}
+.tracking-legend[hidden] { display: none; }
+.legend-demo-marker, .demo-pill { background: #f59e0b; color: #451a03; border-radius: 5px; padding: 0.1rem 0.3rem; font-size: 0.58rem; font-weight: 900; letter-spacing: 0.08em; }
+.bus-item--demo { border: 2px dashed #f59e0b; background: #fff7ed; }
+:global(html.dark) .tracking-legend, :global(html.dark) .bus-item--demo { background: #431407; color: #fed7aa; }
+:global(.bus-marker-demo) { filter: drop-shadow(0 2px 4px rgba(154,52,18,0.35)); }
 
 /* Buses panel */
 .buses-panel, .stops-panel {
@@ -144,6 +164,7 @@ const t = {
 // TRACKING PAGE — Buses en tiempo real + Heatmap
 // ═══════════════════════════════════════════════════
 import { loadLeaflet } from '../../utils/leafletLoader';
+import { escapeHtml } from '../../utils/utils';
 
 let map: import('leaflet').Map | null = null;
 let busMarkers: Map<string, import('leaflet').Marker> = new Map();
@@ -154,10 +175,11 @@ let currentRoute = '';
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 // Crear SVG bus 2D animado
-function createBusSvg(color: string, heading: number, occupancy: number): string {
+function createBusSvg(color: string, heading: number, occupancy: number, isDemo = false): string {
   const occColor = occupancy < 40 ? '#22c55e' : occupancy < 75 ? '#f59e0b' : '#ef4444';
   return `
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  ${isDemo ? '<circle cx="24" cy="24" r="22" fill="#fff7ed" stroke="#f59e0b" stroke-width="2.5" stroke-dasharray="4 3"/><text x="24" y="6" text-anchor="middle" fill="#9a3412" font-size="5" font-weight="900">DEMO</text>' : ''}
   <g transform="rotate(${heading},24,24)">
     <!-- Sombra -->
     <ellipse cx="24" cy="42" rx="12" ry="3" fill="rgba(0,0,0,0.2)"/>
@@ -190,12 +212,12 @@ function createBusSvg(color: string, heading: number, occupancy: number): string
 </svg>`;
 }
 
-function createBusIcon(color: string, heading: number, occupancy: number): import('leaflet').DivIcon {
+function createBusIcon(color: string, heading: number, occupancy: number, isDemo: boolean): import('leaflet').DivIcon {
   const L = (window as any).L;
   return L.divIcon({
-    html: createBusSvg(color, heading, occupancy),
+    html: createBusSvg(isDemo ? '#f59e0b' : color, heading, occupancy, isDemo),
     iconSize: [48, 48], iconAnchor: [24, 34],
-    className: 'bus-marker-svg',
+    className: isDemo ? 'bus-marker-svg bus-marker-demo' : 'bus-marker-svg',
     popupAnchor: [0, -34]
   });
 }
@@ -254,12 +276,29 @@ async function loadRoutes() {
   } catch {}
 }
 
+const modeLabels: Record<string, string> = lang === 'es'
+  ? { live: 'En vivo', mixed: 'Mixto', demo: 'Demo', offline: 'Sin conexión' }
+  : { live: 'Live', mixed: 'Mixed', demo: 'Demo', offline: 'Offline' };
+
+function updateTrackingMode(mode: string, hasDemoUnits: boolean) {
+  const safeMode = ['live', 'mixed', 'demo', 'offline'].includes(mode) ? mode : 'offline';
+  const badge = document.getElementById('tracking-mode-badge');
+  const label = document.getElementById('tracking-mode-label');
+  const legend = document.getElementById('tracking-legend');
+  badge?.classList.remove('mode-live', 'mode-mixed', 'mode-demo', 'mode-offline');
+  badge?.classList.add(`mode-${safeMode}`);
+  if (label) label.textContent = modeLabels[safeMode];
+  if (legend) legend.hidden = !hasDemoUnits;
+}
+
 // Actualizar buses en el mapa
 async function refreshBuses() {
   try {
     const url = currentRoute ? `/api/tracking?route_id=${currentRoute}` : '/api/tracking';
     const res = await fetch(url);
-    const units: any[] = await res.json();
+    const payload = await res.json();
+    const units: any[] = Array.isArray(payload) ? payload : payload.units || [];
+    updateTrackingMode(Array.isArray(payload) ? 'demo' : payload.mode, units.some(unit => unit.is_stub));
 
     // Remover buses que ya no están activos
     const activeIds = new Set(units.map(u => u.id));
@@ -279,17 +318,17 @@ async function refreshBuses() {
       const color = routeColors[unit.route_id] || '#0d9488';
       const heading = unit.heading || 0;
       const occ = unit.occupancy_pct || 50;
-      const icon = createBusIcon(color, heading, occ);
+      const icon = createBusIcon(color, heading, occ, Boolean(unit.is_stub));
       
       const popupContent = `
         <div style="min-width:160px;font-family:system-ui;">
-          <div style="font-weight:700;font-size:0.9rem;">${unit.route_id}</div>
+          <div style="font-weight:700;font-size:0.9rem;">${escapeHtml(unit.route_id)}</div>
           <div style="font-size:0.75rem;color:#64748b;margin-top:0.2rem;">
-            ${unit.stop_name || 'En ruta'}<br>
+            ${escapeHtml(unit.stop_name || 'En ruta')}<br>
             Vel: ${unit.speed_kmh || 0} km/h<br>
             Ocupación: ${occ}%
           </div>
-          ${unit.is_stub ? '<div style="font-size:0.65rem;color:#94a3b8;margin-top:0.2rem;">📍 Posición simulada</div>' : ''}
+          ${unit.is_stub ? '<div style="font-size:0.7rem;color:#9a3412;font-weight:800;margin-top:0.3rem;">⚠ DEMO · Posición simulada</div>' : ''}
         </div>`;
 
       if (busMarkers.has(unit.id)) {
@@ -314,11 +353,11 @@ async function refreshBuses() {
       const occClass = occ < 40 ? 'occ-low' : occ < 75 ? 'occ-mid' : 'occ-high';
       const color = routeColors[u.route_id] || '#0d9488';
       return `
-      <div class="bus-item" onclick="flyToBus(${u.lat},${u.lng})">
-        <div class="bus-svg">${createBusSvg(color, u.heading || 0, occ)}</div>
+      <div class="bus-item ${u.is_stub ? 'bus-item--demo' : ''}" onclick="flyToBus(${Number(u.lat)},${Number(u.lng)})">
+        <div class="bus-svg">${createBusSvg(u.is_stub ? '#f59e0b' : color, Number(u.heading) || 0, occ, Boolean(u.is_stub))}</div>
         <div class="bus-info">
-          <div class="bus-route">Ruta ${u.route_id}</div>
-          <div class="bus-details">${u.stop_name || 'En ruta'} · ${u.speed_kmh || 0} km/h${u.is_stub ? ' · demo' : ''}</div>
+          <div class="bus-route">Ruta ${escapeHtml(u.route_id)} ${u.is_stub ? '<span class="demo-pill">DEMO</span>' : ''}</div>
+          <div class="bus-details">${escapeHtml(u.stop_name || 'En ruta')} · ${Number(u.speed_kmh) || 0} km/h</div>
           <div class="bus-occ">
             <div class="occ-bar"><div class="occ-fill ${occClass}" style="width:${occ}%"></div></div>
             <span style="font-size:0.65rem;color:var(--text-tertiary)">${occ}%</span>
@@ -327,6 +366,7 @@ async function refreshBuses() {
       </div>`;
     }).join('');
   } catch (e) {
+    updateTrackingMode('offline', false);
     console.error('[tracking] refresh buses:', e);
   }
 }

--- a/src/pages/api/tracking.ts
+++ b/src/pages/api/tracking.ts
@@ -38,8 +38,28 @@ async function ensureSchema() {
 }
 
 // Realistic stub positions keyed by route_id
+export type TrackingMode = 'live' | 'mixed' | 'demo' | 'offline';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SqlRow = Record<string, any>;
+type TrackingUnit = SqlRow & { source: 'live' | 'demo'; is_stub: boolean };
+
+export interface TrackingPayload {
+  mode: TrackingMode;
+  units: TrackingUnit[];
+  meta: {
+    database: 'available' | 'unavailable';
+    live_units: number;
+    demo_units: number;
+    stubs_enabled: boolean;
+    generated_at: string;
+  };
+}
+
+function areStubsEnabled() {
+  const configured = process.env.TRACKING_STUBS_ENABLED ?? import.meta.env.TRACKING_STUBS_ENABLED;
+  return configured?.toLowerCase() !== 'false';
+}
 
 const STUB_POSITIONS: Record<string, Array<{lat:number;lng:number;stop:string}>> = {
   'R1':  [{lat:21.1714,lng:-86.8219,stop:'El Crucero'},{lat:21.1588,lng:-86.8455,stop:'Av. Kabah'},{lat:21.1430,lng:-86.8460,stop:'Zona Hotelera'}],
@@ -68,41 +88,67 @@ function stubUnits(routeId: string) {
       heading: (i * 120) % 360,
       stop_name: pos.stop,
       updated_at: new Date(now - i * 45000).toISOString(),
+      source: 'demo' as const,
       is_stub: true,
     };
   });
 }
 
+export function createTrackingPayload(
+  rows: SqlRow[],
+  routeId: string,
+  database: 'available' | 'unavailable',
+  stubsEnabled: boolean,
+): TrackingPayload {
+  const liveUnits: TrackingUnit[] = rows.map(row => ({ ...row, source: 'live', is_stub: false }));
+  const liveRouteIds = new Set(liveUnits.map(row => row.route_id));
+  const targetRoutes = routeId ? [routeId] : Object.keys(STUB_POSITIONS);
+  const demoUnits = stubsEnabled
+    ? targetRoutes.filter(id => !liveRouteIds.has(id)).flatMap(stubUnits)
+    : [];
+
+  let mode: TrackingMode;
+  if (liveUnits.length && demoUnits.length) mode = 'mixed';
+  else if (liveUnits.length || (database === 'available' && !demoUnits.length)) mode = 'live';
+  else if (demoUnits.length) mode = 'demo';
+  else mode = 'offline';
+
+  return {
+    mode,
+    units: [...liveUnits, ...demoUnits],
+    meta: {
+      database,
+      live_units: liveUnits.length,
+      demo_units: demoUnits.length,
+      stubs_enabled: stubsEnabled,
+      generated_at: new Date().toISOString(),
+    },
+  };
+}
+
+function jsonResponse(payload: TrackingPayload) {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+  });
+}
+
 export const GET: APIRoute = async ({ url }) => {
-  const route_id = url.searchParams.get('route_id') || '';
+  const routeId = url.searchParams.get('route_id') || '';
+  const stubsEnabled = areStubsEnabled();
 
   try {
     await ensureSchema();
     const sql = getDb();
-    const query = route_id
-      ? sql`SELECT *, updated_at::text AS updated_at FROM tracking_units WHERE route_id = ${route_id} AND updated_at > NOW() - INTERVAL '5 minutes' ORDER BY updated_at DESC`
+    const query = routeId
+      ? sql`SELECT *, updated_at::text AS updated_at FROM tracking_units WHERE route_id = ${routeId} AND updated_at > NOW() - INTERVAL '5 minutes' ORDER BY updated_at DESC`
       : sql`SELECT *, updated_at::text AS updated_at FROM tracking_units WHERE updated_at > NOW() - INTERVAL '5 minutes' ORDER BY route_id, updated_at DESC`;
 
     const rows = await query as SqlRow[];
-
-    // Supplement with stubs for any route that has no live data
-    const liveRouteIds = new Set(rows.map((r: SqlRow) => r.route_id));
-    const targetRoutes = route_id ? [route_id] : Object.keys(STUB_POSITIONS);
-    const stubRows = targetRoutes
-      .filter(rid => !liveRouteIds.has(rid))
-      .flatMap((rid: string) => stubUnits(rid));
-
-    return new Response(JSON.stringify([...rows, ...stubRows]), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
-    });
+    return jsonResponse(createTrackingPayload(rows, routeId, 'available', stubsEnabled));
   } catch {
-    logger.warn('[API/Tracking] DB unavailable, returning stubs');
-    const units = route_id ? stubUnits(route_id) : Object.keys(STUB_POSITIONS).flatMap(stubUnits);
-    return new Response(JSON.stringify(units), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
-    });
+    logger.warn(`[API/Tracking] DB unavailable, stubs ${stubsEnabled ? 'enabled' : 'disabled'}`);
+    return jsonResponse(createTrackingPayload([], routeId, 'unavailable', stubsEnabled));
   }
 };
 

--- a/src/tests/tracking-api.test.ts
+++ b/src/tests/tracking-api.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { createTrackingPayload } from '../pages/api/tracking';
+
+const liveUnit = {
+  id: 'real-r1-01',
+  route_id: 'R1',
+  lat: 21.1714,
+  lng: -86.8219,
+  speed_kmh: 32,
+  heading: 90,
+  stop_name: 'El Crucero',
+  updated_at: '2026-06-07T12:00:00.000Z',
+};
+
+describe('/api/tracking response modes', () => {
+  it('returns live metadata and only real units when DB data is available for a route', () => {
+    const response = createTrackingPayload([liveUnit], 'R1', 'available', true);
+
+    expect(response.mode).toBe('live');
+    expect(response.meta).toMatchObject({ database: 'available', live_units: 1, demo_units: 0, stubs_enabled: true });
+    expect(response.units).toEqual([expect.objectContaining({ id: 'real-r1-01', source: 'live', is_stub: false })]);
+  });
+
+  it('returns demo metadata and clearly marked stubs when the DB is empty', () => {
+    const response = createTrackingPayload([], 'R1', 'available', true);
+
+    expect(response.mode).toBe('demo');
+    expect(response.meta).toMatchObject({ database: 'available', live_units: 0, demo_units: 3, stubs_enabled: true });
+    expect(response.units).toHaveLength(3);
+    expect(response.units.every(unit => unit.source === 'demo' && unit.is_stub)).toBe(true);
+  });
+
+  it('returns offline with no units when the DB is unavailable and production stubs are disabled', () => {
+    const response = createTrackingPayload([], 'R1', 'unavailable', false);
+
+    expect(response.mode).toBe('offline');
+    expect(response.units).toEqual([]);
+    expect(response.meta).toMatchObject({ database: 'unavailable', live_units: 0, demo_units: 0, stubs_enabled: false });
+  });
+
+  it('returns mixed and labels every source when live and demo units coexist', () => {
+    const response = createTrackingPayload([liveUnit], '', 'available', true);
+
+    expect(response.mode).toBe('mixed');
+    expect(response.meta.live_units).toBe(1);
+    expect(response.meta.demo_units).toBeGreaterThan(0);
+    expect(new Set(response.units.map(unit => unit.source))).toEqual(new Set(['live', 'demo']));
+  });
+});


### PR DESCRIPTION
### Motivation
- Evitar que unidades simuladas se muestren indistinguibles de unidades reales y permitir desactivar los stubs en producción.
- Mostrar un estado de rastreo explícito (badge) para que el usuario sepa si los datos son `live`, `mixed`, `demo` o `offline`.
- Proveer una leyenda y estilo visual inequívoco para unidades demo y agregar pruebas que cubran DB disponible, DB vacía y DB no disponible.

### Description
- Cambia la API `/api/tracking` para devolver un `TrackingPayload` con `mode: 'live'|'mixed'|'demo'|'offline'`, conteos y `meta` y añade `source: 'live'|'demo'` e `is_stub` por unidad; la lógica central está en `createTrackingPayload` (archivo `src/pages/api/tracking.ts`).
- Introduce la variable de entorno `TRACKING_STUBS_ENABLED` que, cuando está a `false`, desactiva totalmente los stubs en producción y hace que la API vaya a `offline` si no hay datos reales.
- Actualiza la UI (`src/pages/[lang]/tracking.astro`) para: mostrar un badge dinámico con estados localizados, mostrar una leyenda visible para unidades demo, dibujar marcadores demo con estilo ámbar/borde discontinuo/etiqueta `DEMO`, y escapar valores con `escapeHtml` antes de insertar en `innerHTML`.
- Documenta la nueva variable en `.env.example` y `DEPLOY.md` y agrega pruebas unitarias `src/tests/tracking-api.test.ts` que cubren DB con datos, DB vacía, DB no disponible con stubs off y caso mixto.

### Testing
- Ejecuté las pruebas unitarias específicas con `pnpm exec vitest run src/tests/tracking-api.test.ts` y pasaron (4 tests passed).
- Corro `pnpm test -- --run` (suite completa) y informó `160 passed | 1 todo` indicando que la suite existente sigue verde.
- Verifiqué tipado y bundling con `pnpm exec astro check` y `pnpm build`, ambos completaron sin errores (build OK).
- Linting con `pnpm lint` y auditoría `pnpm audit:survival` pasaron correctamente (sin problemas detectados).
- Intenté captura visual con Playwright pero la descarga del navegador falló por un bloqueo HTTP 403 en el entorno, por lo que la captura no pudo generarse (automated visual test failed due to browser download error).
- Verificación runtime rápida: petición `curl 'http://localhost:4321/api/tracking?route_id=R1'` devolvió payload con `mode` y `meta` adecuados y unidades marcadas como `demo` cuando la DB no estuvo disponible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25720a3e088325a98a518ff515f61e)