### PR TITLE
fix(tracking): restore bus markers for wrapped tracking payloads

### DIFF
--- a/src/components/InteractiveMap.astro
+++ b/src/components/InteractiveMap.astro
@@ -85,7 +85,8 @@ const isEs = Astro.url.pathname.includes("/es/");
       ]);
       if (!trackRes.ok || !routesRes.ok) return;
 
-      const units = await trackRes.json();
+      const trackingPayload = await trackRes.json();
+      const units = Array.isArray(trackingPayload) ? trackingPayload : trackingPayload?.units || [];
       const routesData = await routesRes.json();
       const routes = routesData.rutas || routesData;
       const colorMap = {};


### PR DESCRIPTION
### Motivation
- The `/api/tracking` endpoint was changed to return a `TrackingPayload` wrapper instead of a bare array, but the main interactive map still parsed the response as an array and called `.map()`, causing `units.map is not a function` and bus markers to stop rendering.

### Description
- Unwrap the new tracking payload in `src/components/InteractiveMap.astro` by accepting either a legacy array or the new `{ units }` wrapper and falling back to an empty array when missing (`const units = Array.isArray(trackingPayload) ? trackingPayload : trackingPayload?.units || [];`).
- Preserve compatibility with legacy bare-array responses so both shapes are supported without changing the API.
- Keep mapping and marker logic unchanged aside from using the normalized `units` array so demo/live unit rendering resumes normally.

### Testing
- Ran the focused unit tests with `pnpm exec vitest run src/tests/tracking-api.test.ts` and all 4 tests passed.
- Ran the full test suite with `pnpm test -- --run` and observed `160 passed | 1 todo` (suite remains green).
- Performed linting with `pnpm lint`, survival audit `pnpm audit:survival`, and type/build checks with `pnpm exec astro check` and `pnpm build`, all of which completed successfully.
- Attempted a Playwright screenshot for visual verification but the environment lacked the Chromium executable so the automated screenshot failed (Playwright install required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25ff7de6288325b73c9b5c18eafa6d)